### PR TITLE
Bump the github group across 1 directory with 2 updates

### DIFF
--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔂 dependency review
-        uses: actions/dependency-review-action@bc41886e18ea39df68b1b1245f4184881938e050 # v4.7.2
+        uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
         with:
           fail-on-severity: "high"
           deny-licenses: "AGPL-1.0, AGPL-3.0"

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
# Description

Bumps the github group with 2 updates in the / directory: [actions/dependency-review-action](https://github.com/actions/dependency-review-action) and [actions/setup-python](https://github.com/actions/setup-python).

Updates actions/dependency-review-action from 4.7.2 to 4.7.3

Updates actions/setup-python from 5 to 6

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/cisco-ospo/oss-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
