### PR TITLE
Set Repo to Public

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -19,7 +19,7 @@ repository:
   topics: benchmarks, cybersecurity, language models
 
   # Either `true` to make the repository private, or `false` to make it public.
-  private: true
+  private: false
 
   # Either `true` to enable issues for this repository, `false` to disable them.
   has_issues: true


### PR DESCRIPTION
# Description

This converts makes our faith repo into an open-source repository.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other - Change Repo Settings

## Checklist

- [X] I have read the [contributing guidelines](/cisco-foundation-ai/faith/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
